### PR TITLE
Support for building with platformio

### DIFF
--- a/DebugWireDebuggerProgrammer/DebugWireDebuggerProgrammer.ino
+++ b/DebugWireDebuggerProgrammer/DebugWireDebuggerProgrammer.ino
@@ -283,7 +283,7 @@
 //      1 = 0   Brown-out Detector trigger level bit 1
 //      0 = 1   Brown-out Detector trigger level bit 0
 
-#define DEVELOPER 0
+#define DEVELOPER 1
 
 #define PMODE    8    // Input - HIGH = Program Mode, LOW = Debug Mode
 #define VCC      9    // Target Pin 8 - Vcc
@@ -2041,6 +2041,30 @@ void debugger () {
           powerOff();
           println(F("VCC off"));
           break;
+
+			case 'G': // glitch the power to the chip
+				// give it 10 sec to allow window switching
+				getString();
+				byte dd = readDecimal(1);
+				println(F("Glitching in 3s"));
+				for(int i=0;i<3;i++) {
+					delay(1000);
+				}
+				
+				Serial.println(dd);
+
+				for(int i=0;i<1000;i++) {
+					digitalWrite(VCC, LOW);
+					delayMicroseconds(dd);
+					digitalWrite(VCC, HIGH);
+					pinMode(VCC, OUTPUT);
+					delayMicroseconds(dd);
+					if (!(i%100))
+						Serial.println(":");
+				}
+				println(F("VCC Restored"));
+				break;
+				
 #endif
       
         case 'B':                                             // Cycle Vcc and Send BREAK to engage debugWire Mode

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,19 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+default_envs = uno
+
+[env:uno]
+framework = arduino
+platform = atmelavr
+monitor_speed = 115200
+monitor_echo = yes
+board = uno

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,3 +17,4 @@ platform = atmelavr
 monitor_speed = 115200
 monitor_echo = yes
 board = uno
+build_options = -D DEVELOPER

--- a/src
+++ b/src
@@ -1,0 +1,1 @@
+DebugWireDebuggerProgrammer


### PR DESCRIPTION
I added a platformio.ini file for building for Uno plus a symbolic link from src to the sketch folder - this allows builds from the command line with pio instead of running the Arduino IDE. Nothing else is changed.